### PR TITLE
allow to specify a folder within the Vault Name, separated by /

### DIFF
--- a/options.html
+++ b/options.html
@@ -1,23 +1,25 @@
 <!DOCTYPE html>
 
 <html>
-  <head>
-    <meta charset="utf-8">
-    <link rel="stylesheet" href="options.css"/>
-  </head>
+
+<head>
+  <meta charset="utf-8">
+  <link rel="stylesheet" href="options.css" />
+</head>
 
 <body>
   <div id="options-content">
-		<h1>
-			Obsidian Clipper
-		</h1>
-		<div class="options-container">
-			<div id="vault-field">
-				<label for="vault-name">Vault Name:</label>
+    <h1>
+      Obsidian Clipper
+    </h1>
+    <div class="options-container">
+      <div id="vault-field">
+        <label for="vault-name">Vault Name:</label>
 
-				<input type="text" id="vault-name" name="vault-name" required>
-				</div>
-		</div>
+        <input type="text" id="vault-name" name="vault-name" required>
+      </div>
+      (add folder with "/")
+    </div>
   </div>
 
   <div id="error-content" class="hidden">

--- a/src/action.ts
+++ b/src/action.ts
@@ -65,7 +65,16 @@ async function openObsidian(clip: Clipping) {
 	let modifiedTitle = clip.title
 		.split(":").join("")
 		.split("/").join("");
-	let uri = `obsidian://new?vault=${options.vaultName}&name=${modifiedTitle}&content=${clip.content}`;
+
+	let [vault, folder] = options.vaultName.split("/")
+
+	if (folder !== undefined) {
+		folder += "/";
+	} else {
+		folder = "";
+	}
+
+	let uri = `obsidian://new?vault=${vault}&name=${folder}${modifiedTitle}&content=${clip.content}`;
 	browser.tabs.create({url: encodeURI(uri), active: true}).then((tab: browser.tabs.Tab) => {
 		// TODO: maybe close tab??
 		console.log(tab)


### PR DESCRIPTION
This fix allows to specify a folder within a vault by separating it with "/". 
Eg. Vault Name: "Main/Web" would store all clipped notes in the vault "Main" inside the folder "Web".