### PR TITLE
encode the clipped content using encodeURIComponent

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -65,14 +65,15 @@ async function openObsidian(clip: Clipping) {
 	let modifiedTitle = clip.title
 		.split(":").join("")
 		.split("/").join("");
-	let uri = `obsidian://new?vault=${options.vaultName}&name=${modifiedTitle}&content=${clip.content}`;
-	browser.tabs.create({url: encodeURI(uri), active: true}).then((tab: browser.tabs.Tab) => {
+	let encodedTitle = encodeURI(modifiedTitle);
+	let encodedVault = encodeURI(options.vaultName);
+	let encodedContent = encodeURIComponent(clip.content);
+	let uri = `obsidian://new?vault=${encodedVault}&name=${encodedTitle}&content=${encodedContent}`;
+	browser.tabs.create({url: uri, active: true}).then((tab: browser.tabs.Tab) => {
 		// TODO: maybe close tab??
 		console.log(tab)
 	});
 }
-
-
 
 function listenForMessages(obj: object, sender: browser.runtime.MessageSender): void {
 	let message = obj as Message


### PR DESCRIPTION
encode the clipped content using encodeURIComponent to handle embedded URLs.

The text in Obsidian may be truncated if the clipped text contains a URL which includes =, &, ;, etc.  This change encodes the clipped text using the encodeURIComponent.